### PR TITLE
Fix for Mavericks (and other systems using libc++). Eliminate warnings.

### DIFF
--- a/ext/sparsehash/google/sparsehash/sparseconfig.h
+++ b/ext/sparsehash/google/sparsehash/sparseconfig.h
@@ -13,6 +13,18 @@
     #define HASH_NAMESPACE stdext
     /* The system-provided hash function including the namespace. */
     #define SPARSEHASH_HASH  HASH_NAMESPACE::hash_compare
+
+/* libc++ does not implement the tr1 namespace as it provides
+ * only C++11 support; instead of tr1, the equivalent functionality
+ * is placed in namespace std, so use when it targeting such
+ * systems (OS X 10.7 onwards, various Linux distributions) */
+#elif defined(_LIBCPP_VERSION)
+    /* the location of the header defining hash functions */
+    #define HASH_FUN_H <functional>
+    /* the namespace of the hash<> function */
+    #define HASH_NAMESPACE std
+    /* The system-provided hash function including the namespace. */
+    #define SPARSEHASH_HASH HASH_NAMESPACE::hash
 #else
     /* the location of the header defining hash functions */
     #define HASH_FUN_H <tr1/functional>

--- a/libshiboken/conversions.h
+++ b/libshiboken/conversions.h
@@ -141,8 +141,8 @@ struct Converter<T&>
 template<>
 struct Converter<void*>
 {
-    static inline bool checkType(PyObject* pyObj) { return false; }
-    static inline bool isConvertible(PyObject* pyobj) { return true; }
+    static inline bool checkType(PyObject*) { return false; }
+    static inline bool isConvertible(PyObject*) { return true; }
     static PyObject* toPython(void* cppobj)
     {
         if (!cppobj)
@@ -291,7 +291,7 @@ struct OverFlowChecker<T, false>
 template<>
 struct OverFlowChecker<PY_LONG_LONG, true>
 {
-    static bool check(const PY_LONG_LONG& value)
+    static bool check(const PY_LONG_LONG&)
     {
         return false;
     }
@@ -300,7 +300,7 @@ struct OverFlowChecker<PY_LONG_LONG, true>
 template<>
 struct OverFlowChecker<double, true>
 {
-    static bool check(const double& value)
+    static bool check(const double&)
     {
         return false;
     }


### PR DESCRIPTION
On Mavericks and other systems using libc++, only C++11
support is provided. Some things, including the hash
class, are moved from the tr1 namespace to std.

This patch is adapted from
[homebrew pull 23867](https://github.com/mxcl/homebrew/pull/23867).

Also, modify shiboken headers and code generator so that generated code compiles with far fewer warnings.
