### PR TITLE
operators: skip nullary operators

### DIFF
--- a/ApiExtractor/abstractmetabuilder.cpp
+++ b/ApiExtractor/abstractmetabuilder.cpp
@@ -653,8 +653,12 @@ bool AbstractMetaBuilder::build(QIODevice* input)
                                         + m_dom->findFunctions("operator~")
                                         + m_dom->findFunctions("operator>");
 
-        foreach (FunctionModelItem item, binaryOperators)
+        foreach (FunctionModelItem item, binaryOperators) {
+            if (item->arguments().empty()) {
+                continue;
+            }
             traverseOperatorFunction(item);
+        }
     }
 
     {


### PR DESCRIPTION
The function assumes at least unary operators.

---

@vibraphone This seems to fix the shiboken problem. I'm not sure what got added that triggered this though…
